### PR TITLE
tasks: accept symbolic links for `local*.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+local*.sh
 settings.json

--- a/tasks.sh
+++ b/tasks.sh
@@ -48,7 +48,7 @@ COMMAND=$1
 : ${SCRIPT_DIR:=`dirname "${SCRIPT}"`}
 
 # Let the user override environment variables for their special needs
-files_to_source=$(find ${SCRIPT_DIR} -maxdepth 1 -type f -name "local*.sh")
+files_to_source=$(find ${SCRIPT_DIR} -maxdepth 1 -xtype f -name "local*.sh")
 for file in $files_to_source; do
   source "$file"
 done


### PR DESCRIPTION
First, thank you for this extension! I'm now trying VSCode for the kernel dev, and this extension seems to help to set up stuff! (I'm using a [docker image](https://github.com/multipath-tcp/mptcp-upstream-virtme-docker) to build the kernel in a separate dir and start the VM, but I should be able to use it thanks to a `local*.sh` script :) )

In some cases, it might be useful to use symbolic links for the `local*.sh` files, e.g. to use one from another repository where the file can be tracked and even shared.

Switching from `-type` to `-xtype` will do the trick: `-xtype` checks the type of the file that `-type` does not check.