### PR TITLE
settings: load settings-extra.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 settings.json
+settings-extra.json

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ the `Ctrl+P` dialog box):
 *   Customize per-workspace VS-Code settings the normal way (edit local
     `.vscode/settings.json`, or use `Ctrl+Shift+P` -> "Preferences: Open
     Settings (UI)"). Note that fields that exist in `settings.jsonnet` will get
-    overwritten when you run the `update` task. Also, comments in your
+    overwritten when you run the `update` task. If needed, extra settings can be
+    added in `.vscode/settings-extra.json` file. Also, comments in your
     `.vscode/settings.json` will get deleted.
 *   **Autostart** commands or codes at VM start time by modifying the content of
     `.vscode/autostart/` (eg: always run tests that exercise the kernel

--- a/settings.jsonnet
+++ b/settings.jsonnet
@@ -1,9 +1,12 @@
 // This is a jsonnet file, to evaluate it on the command-line use
 //
-// jsonnet --ext-code-file old_settings=<path to old settings> <path to this file>
+// jsonnet \
+//   --ext-code-file old_settings=<path to old settings> \
+//   --ext-code-file extra_settings=<path to extra settings> \
+//   <path to this file>
 //
 // JSonnet is a superset of JSON. Here we are using a minimal subset of
-// JSonnet's extra freatures, see the "External Variables" and "Object
+// JSonnet's extra features, see the "External Variables" and "Object
 // Orientation" section of jsonnet tutorials (plus we use comments).
 std.extVar('old_settings') + {
   "files.exclude": {
@@ -87,4 +90,4 @@ std.extVar('old_settings') + {
   "systemtap-assistant.output": ".vscode/autostart/tracer.stp",
   "systemtap-assistant.deploy-task": "Build systemtap tracer",
   "debug.onTaskErrors": "debugAnyway"
-}
+} + std.extVar('extra_settings')

--- a/tasks.sh
+++ b/tasks.sh
@@ -455,8 +455,14 @@ EOF
       # Seed JSonnet with empty object
       echo "{}" > "settings.json"
     fi
+    if [ ! -e "settings-extra.json" ]; then
+      # Seed JSonnet with empty object
+      echo "{}" > "settings-extra.json"
+    fi
     tmp="$(mktemp --suffix=.json)"
-    jsonnet settings.jsonnet --ext-code-file old_settings="settings.json" > "${tmp}"
+    jsonnet settings.jsonnet \
+      --ext-code-file old_settings="settings.json" \
+      --ext-code-file extra_settings="settings-extra.json" > "${tmp}"
     mv "$tmp" settings.json
     ;;
   *)


### PR DESCRIPTION
This allows users to manage extra settings in an external file, e.g. to use one from another repository where the file can be tracked and even shared.

Also, by loading it at the end, it can override some "default" settings.