### PR TITLE
Fix arm64 compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 sudo install -o root -g root -m 644 microsoft.gpg /usr/share/keyrings/microsoft-archive-keyring.gpg
 sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
 sudo apt update
-sudo apt install code gdb-multiarch ccache clang clangd llvm lld libguestfs-tools libssl-dev trace-cmd python3-pip jsonnet libelf-dev bison bindfs mmdebstrap proot systemtap flex yacc bc debian-archive-keyring qemu-system-arm crossbuild-essential-arm64 qemu qemu-user-static binfmt-support
+sudo apt install code gdb-multiarch ccache clang clangd llvm lld libguestfs-tools libssl-dev trace-cmd python3-pip jsonnet libelf-dev bison bindfs mmdebstrap proot systemtap flex yacc bc debian-archive-keyring qemu-system-arm crossbuild-essential-arm64 qemu-user-static binfmt-support
 for fmt in aarch64 alpha arm armeb cris hexagon hppa loongarch64 m68k microblaze mips mipsel mipsn32 mipsn32el mips64 mips64el ppc ppc64 ppc64le riscv32 riscv64 s390x sh4 sh4eb sparc sparc32plus sparc64 xtensa xtensaeb; do
 	sudo update-binfmts --import qemu-$fmt;
 done

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 sudo install -o root -g root -m 644 microsoft.gpg /usr/share/keyrings/microsoft-archive-keyring.gpg
 sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
 sudo apt update
-sudo apt install code gdb-multiarch ccache clang clangd llvm lld libguestfs-tools libssl-dev trace-cmd python3-pip jsonnet libelf-dev bison bindfs mmdebstrap proot systemtap flex yacc bc debian-archive-keyring
+sudo apt install code gdb-multiarch ccache clang clangd llvm lld libguestfs-tools libssl-dev trace-cmd python3-pip jsonnet libelf-dev bison bindfs mmdebstrap proot systemtap flex yacc bc debian-archive-keyring qemu-system-arm crossbuild-essential-arm64 qemu qemu-user-static binfmt-support
+for fmt in aarch64 alpha arm armeb cris hexagon hppa loongarch64 m68k microblaze mips mipsel mipsn32 mipsn32el mips64 mips64el ppc ppc64 ppc64le riscv32 riscv64 s390x sh4 sh4eb sparc sparc32plus sparc64 xtensa xtensaeb; do
+	sudo update-binfmts --import qemu-$fmt;
+done
 ```
 
 For VS Code to keep track of all the files in your kernel source tree:

--- a/tasks.sh
+++ b/tasks.sh
@@ -86,6 +86,7 @@ if [ "${TARGET_ARCH}" = "x86_64" ]; then
   : ${SERIAL_TTY:="ttyS0"}
   : ${SYZKALLER_TARGETARCH:="amd64"}
   : ${ROOT_MNT:="/dev/sda"}
+  : ${CROSS_COMPILE:=""}
 elif [ "${TARGET_ARCH}" = "arm64" ]; then
   : ${VMLINUX:="Image"}
   : ${CLANG_TARGET:="aarch64-linux-gnu"}
@@ -97,6 +98,7 @@ elif [ "${TARGET_ARCH}" = "arm64" ]; then
   : ${PROOT_ARGS:="-q qemu-aarch64-static"}
   : ${SYZKALLER_TARGETARCH:="arm4"}
   : ${ROOT_MNT:="/dev/vda"}
+  : ${CROSS_COMPILE:="aarch64-linux-gnu-"}
 else
   echo "Unsupported TARGET_ARCH:" $TARGET_ARCH
   exit 2
@@ -180,7 +182,7 @@ case "${COMMAND}" in
     # Enable reproducible builds for ccache
     export KBUILD_BUILD_TIMESTAMP=""
     # Generate not only the kernel but also the clangd config
-    CMD="${MAKE} ${SILENT_BUILD_FLAG} ARCH=${TARGET_ARCH} all compile_commands.json"
+    CMD="${MAKE} ${SILENT_BUILD_FLAG} ARCH=${TARGET_ARCH} CROSS_COMPILE=${CROSS_COMPILE} all compile_commands.json"
     echo ${CMD}
     eval ${CMD} &
     spinner $!


### PR DESCRIPTION
The README.md file does not include the quemu packages required for arm64 platforms, this causes issues with the `create-rootfs` sub command in `task.sh`

This pull request updates the packages required on README.md and adds the missing `CROSS_COMPILER` macro to prevent errors when trying to create the rootfs for arm64 platforms.

Additionally the package list now includes the toolchain required to build arm64 platforms.