### PR TITLE
Fix build in subdirectory

### DIFF
--- a/local.sh
+++ b/local.sh
@@ -10,7 +10,8 @@
 # export PATH=$HOME/qemu/bin/:$PATH
 
 ## Generate objects in a subdirectory
-# MAKE="$MAKE O=.vscode/build-$TARGET_ARCH/"
+# BUILD_DIR="build"
+# MAKE="$MAKE O=${BUILD_DIR}/"
 
 ## Enable some random kernel CONFIG by default as part of the .config generation
 # if [ $COMMAND = "defconfig" ]; then


### PR DESCRIPTION
Building in a subdirectory (by modifying local.sh) doesn't currently work. User overrides come too early (and don't actually override defaults) and defconfig target is not aware of the subdirectory.

Fix it by defining a BUILD_DIR variable and by moving overrides after defaults.