### PR TITLE
Use llvm-objcopy in gdb-add-index to fix vmlinux format recognition issue

### DIFF
--- a/tasks.sh
+++ b/tasks.sh
@@ -193,7 +193,7 @@ case "${COMMAND}" in
   "gdb-index")
     # Hitting a breakpoint is *much* faster if we pre-build a gdb symbol index
     if ! readelf -S vmlinux | grep -q ".gdb_index"; then
-      GDB=gdb-multiarch gdb-add-index vmlinux
+      OBJCOPY=llvm-objcopy GDB=gdb-multiarch gdb-add-index vmlinux
     fi
     ;;
 # Rootfs management


### PR DESCRIPTION
This PR updates the `gdb-add-index` task to explicitly use `llvm-objcopy` instead of the GNU `objcopy`. This change addresses the following error encountered when processing `vmlinux`:

`objcopy: Unable to recognise the format of the input file `vmlinux``

`llvm-objcopy` handles the format of `vmlinux` correctly, preventing the failure and allowing the debug index to be added successfully.

**Changes**
Force `OBJCOPY=llvm-objcopy` when running `gdb-add-index`.

**Rationale**
Using `llvm-objcopy` ensures compatibility with certain kernel builds where `GNU objcopy` fails to recognize the file format.