### PR TITLE
Fix sourcing local scripts when SCRIPT_DIR is a symlink

### DIFF
--- a/tasks.sh
+++ b/tasks.sh
@@ -48,7 +48,7 @@ COMMAND=$1
 : ${SCRIPT_DIR:=`dirname "${SCRIPT}"`}
 
 # Let the user override environment variables for their special needs
-files_to_source=$(find ${SCRIPT_DIR} -maxdepth 1 -xtype f -name "local*.sh")
+files_to_source=$(find ${SCRIPT_DIR}/ -maxdepth 1 -xtype f -name "local*.sh")
 for file in $files_to_source; do
   source "$file"
 done


### PR DESCRIPTION
# Issue Description

This PR addresses an issue where local scripts (`local*.sh`) were not being sourced correctly when `SCRIPT_DIR` is a symlink. The problem occurred because the `find` command did not treat  `SCRIPT_DIR` as a  directory, causing the sourcing of local scripts to fail.

# Solution

By appending a forward slash to `SCRIPT_DIR`, we ensure that `find` consistently treats it as a directory, even when it’s a symlink. This fix enables the project to be symlinked into multiple kernel trees without issues.

Thanks,
Ali