### PR TITLE
Replace mmdebstrap with mkosi to improve compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 sudo install -o root -g root -m 644 microsoft.gpg /usr/share/keyrings/microsoft-archive-keyring.gpg
 sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/vscode stable main" > /etc/apt/sources.list.d/vscode.list'
 sudo apt update
-sudo apt install code gdb-multiarch ccache clang clangd llvm lld libguestfs-tools libssl-dev trace-cmd python3-pip jsonnet libelf-dev bison bindfs mmdebstrap proot systemtap flex yacc bc debian-archive-keyring
+sudo apt install code gdb-multiarch ccache clang clangd llvm lld libguestfs-tools libssl-dev trace-cmd python3-pip jsonnet libelf-dev bison bindfs mkosi proot systemtap flex yacc bc debian-archive-keyring
 ```
 
 For VS Code to keep track of all the files in your kernel source tree:

--- a/tasks.sh
+++ b/tasks.sh
@@ -79,7 +79,7 @@ fi
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   : ${VMLINUX:="bzImage"}
   : ${CLANG_TARGET:="x86_64-linux-gnu"}
-  : ${DEBIAN_TARGET_ARCH:="x86-64"}
+  : ${MKOSI_TARGET_ARCH:="x86-64"}
   : ${TOOLS_SRCARCH:="x86"}
   : ${QEMU_BIN:="qemu-system-x86_64"}
   : ${QEMU_CMD:="${QEMU_BIN} -enable-kvm -cpu host -machine q35 -bios qboot.rom"}
@@ -89,7 +89,7 @@ if [ "${TARGET_ARCH}" = "x86_64" ]; then
 elif [ "${TARGET_ARCH}" = "arm64" ]; then
   : ${VMLINUX:="Image"}
   : ${CLANG_TARGET:="aarch64-linux-gnu"}
-  : ${DEBIAN_TARGET_ARCH:="arm64"}
+  : ${MKOSI_TARGET_ARCH:="arm64"}
   : ${TOOLS_SRCARCH:="arm64"}
   : ${QEMU_BIN:="qemu-system-aarch64"}
   : ${QEMU_CMD:="${QEMU_BIN} -cpu max -machine virt"}
@@ -217,7 +217,7 @@ case "${COMMAND}" in
 
       # Debian rootfs generation and config setting
       sudo mkosi --package=ssh,acpid,acpi-support-base,gdb,systemtap,file,psmisc,strace,vim,bpftool,bpftrace,trace-cmd,linux-perf \
-      --architecture=${DEBIAN_TARGET_ARCH} --distribution=debian --release=unstable --output-dir=${img_mnt} --format=directory
+      --architecture=${MKOSI_TARGET_ARCH} --distribution=debian --release=unstable --output-dir=${img_mnt} --format=directory
 
       # Move mkosi-generated rootfs from ${img_mnt}/image to ${img_mnt} to match script's expected directory structure
       sudo mv ${img_mnt}/image/* ${img_mnt} && sudo rmdir ${img_mnt}/image

--- a/tasks.sh
+++ b/tasks.sh
@@ -216,8 +216,9 @@ case "${COMMAND}" in
           --create-with-perms=0644,ud+X:gd-rwX:od-rwX ${img_mnt} ${img_bind_mnt}
 
       # Debian rootfs generation and config setting
-      sudo mkosi --package=ssh,acpid,acpi-support-base,gdb,systemtap,file,psmisc,strace,vim,bpftool,bpftrace,trace-cmd,linux-perf \
-      --architecture=${MKOSI_TARGET_ARCH} --distribution=debian --release=unstable --output-dir=${img_mnt} --format=directory
+      sudo mkosi --architecture=${MKOSI_TARGET_ARCH} --distribution=debian --release=unstable --output-dir=${img_mnt} --format=directory \
+      --package=ssh,acpid,acpi-support-base,gdb,systemtap,file,psmisc,strace,vim,bpftool,bpftrace,trace-cmd,linux-perf \
+      --package=apt,less,login,iputils-ping,iproute2,cron,e2fsprogs,systemd-sysv,cpio,dhcpd,fdisk,udev,man
 
       # Move mkosi-generated rootfs from ${img_mnt}/image to ${img_mnt} to match script's expected directory structure
       sudo mv ${img_mnt}/image/* ${img_mnt} && sudo rmdir ${img_mnt}/image

--- a/tasks.sh
+++ b/tasks.sh
@@ -79,7 +79,7 @@ fi
 if [ "${TARGET_ARCH}" = "x86_64" ]; then
   : ${VMLINUX:="bzImage"}
   : ${CLANG_TARGET:="x86_64-linux-gnu"}
-  : ${DEBIAN_TARGET_ARCH:="amd64"}
+  : ${DEBIAN_TARGET_ARCH:="x86-64"}
   : ${TOOLS_SRCARCH:="x86"}
   : ${QEMU_BIN:="qemu-system-x86_64"}
   : ${QEMU_CMD:="${QEMU_BIN} -enable-kvm -cpu host -machine q35 -bios qboot.rom"}
@@ -216,8 +216,12 @@ case "${COMMAND}" in
           --create-with-perms=0644,ud+X:gd-rwX:od-rwX ${img_mnt} ${img_bind_mnt}
 
       # Debian rootfs generation and config setting
-      sudo mmdebstrap --include ssh,acpid,acpi-support-base,gdb,systemtap,file,psmisc,strace,vim,bpftool,bpftrace,trace-cmd,linux-perf \
-          --arch ${DEBIAN_TARGET_ARCH} unstable ${img_mnt}
+      sudo mkosi --package=ssh,acpid,acpi-support-base,gdb,systemtap,file,psmisc,strace,vim,bpftool,bpftrace,trace-cmd,linux-perf \
+      --architecture=${DEBIAN_TARGET_ARCH} --distribution=debian --release=unstable --output-dir=${img_mnt} --format=directory
+
+      # Move mkosi-generated rootfs from ${img_mnt}/image to ${img_mnt} to match script's expected directory structure
+      sudo mv ${img_mnt}/image/* ${img_mnt} && sudo rmdir ${img_mnt}/image
+
       echo "debian-vm" > ${img_bind_mnt}/etc/hostname
       echo "nameserver 8.8.8.8" > ${img_bind_mnt}/etc/resolv.conf
       echo "hostfs /host 9p trans=virtio,rw,nofail 0 0" > ${img_bind_mnt}/etc/fstab


### PR DESCRIPTION
# Issue Description

The root filesystem (rootfs) generation step currently relies on `mmdebstrap`, which is unavailable on RHEL-based distributions. This limits the portability of the script and causes failures on systems lacking Debian-specific tooling.

# Solution

Replaced `mmdebstrap` with `mkosi` in `tasks.sh` for rootfs generation. mkosi is widely supported and works on RHEL-based systems, as well as Debian-based ones. The `mkosi` configuration replicates the previous rootfs layout, and a post-processing step moves the generated rootfs to the expected script directory to preserve compatibility with structure.

Thanks,
Ali