### PR TITLE
update deprecated api

### DIFF
--- a/syzbot.ipynb
+++ b/syzbot.ipynb
@@ -65,8 +65,9 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "crashes = pd.read_html(bug_html.nlstr, match=\"Crashes\", extract_links=\"body\")[0]\n",
-    "display(crashes.applymap(lambda val: val[0])[[\"Time\", \"Commit\", \"Syz repro\", \"C repro\"]])"
+    "from io import StringIO\n",
+    "crashes = pd.read_html(StringIO(bug_html.nlstr), match=\"Crashes\", extract_links=\"body\")[0]\n",
+    "display(crashes.map(lambda val: val[0])[[\"Time\", \"Commit\", \"Syz repro\", \"C repro\"]])"
    ]
   },
   {


### PR DESCRIPTION
The applymap() method is deprecated in pandas 2.1.0+. Use map() instead to avoid FutureWarning.
Wrap HTML string with StringIO to comply with pandas best practices and avoid deprecation warnings.