### PR TITLE
Local task overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,9 @@ there).
     task basically just call `tasks.sh` with a different command flag.
 *   `.vscode/tasks.sh` is a bash script with a big switch statement that
     implements all tasks exposed by `tasks.json`. They all share a common
-    preamble customizable
-    locally by local.sh.
+    preamble customizable locally by local.sh. Tasks can be overridden in
+    local.sh by defining a method called `task_<command>()`.
+    Example: "start-wait-dbg" => `task_start_wait_dbg`
 *   `.vscode/settings.jsonnet` [provides per-workspace configuration values to
     VSCode](https://code.visualstudio.com/docs/getstarted/settings) and its
     extensions. This is constructed by `tasks.sh` by evaluating

--- a/local.sh
+++ b/local.sh
@@ -12,6 +12,18 @@
 ## Generate objects in a subdirectory
 # MAKE="$MAKE O=.vscode/build-$TARGET_ARCH/"
 
+#
+## Fully override any task by defining task_<command>().
+## Hyphens in command names become underscores in function names.
+## Example: override "defconfig"
+# task_defconfig() {
+#   if [ ! -f "${WORKSPACE_DIR}/.config" ]; then
+#     eval ${MAKE} ARCH=${TARGET_ARCH} tinyconfig
+#     scripts/config --enable DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT
+#     eval ${MAKE} ARCH=${TARGET_ARCH} olddefconfig
+#   fi
+# }
+
 ## Enable some random kernel CONFIG by default as part of the .config generation
 # if [ $COMMAND = "defconfig" ]; then
 #   trap "scripts/config -e BPF_SYSCALL" EXIT

--- a/tasks.sh
+++ b/tasks.sh
@@ -55,7 +55,8 @@ done
 
 # Default context variables, can be overridden by local.sh or in environment.
 : ${WORKSPACE_DIR:=`realpath -s "${SCRIPT_DIR}/.."`}
-: ${MAKE:="make -j`nproc` LLVM=1 LLVM_IAS=1 CC='ccache clang'"}
+: ${MAKE_VARS:="LLVM=1 LLVM_IAS=1 CC='ccache clang'"}
+: ${MAKE:="make -j`nproc` ${MAKE_VARS}"}
 : ${TARGET_ARCH:="x86_64"}
 : ${TARGET_GDB:="gdb-multiarch"}
 : ${SILENT_BUILD_FLAG="-s"}

--- a/tasks.sh
+++ b/tasks.sh
@@ -130,6 +130,15 @@ fi
     -append \"console=${SERIAL_TTY},115200 root=${ROOT_MNT} rw nokaslr init=/lib/systemd/systemd debug systemd.log_level=info ${KERNEL_CMDLINE_EXTRA}\" \
     -drive file=${IMAGE_PATH},format=raw -kernel ${KERNEL_PATH} ${VM_START_ARGS}"}
 
+# Optional local task override hook:
+# Define task_<command>() in local.sh to fully handle a task.
+# Example: "start-wait-dbg" => task_start_wait_dbg
+TASK_OVERRIDE_FN="task_${COMMAND//-/_}"
+if declare -F "${TASK_OVERRIDE_FN}" > /dev/null; then
+  "${TASK_OVERRIDE_FN}" "$@"
+  exit $?
+fi
+
 case "${COMMAND}" in
 # Virtual machine life-cycle
   "start")


### PR DESCRIPTION
Hi,

Thanks a lot for your work here, this repository has given my workflow a large QoL upgrade.

For my workflow, I wanted a different defconfig task (we merge kconfig fragments to generate an initial .config instead of calling `make defconfig`) and the only way to accomplish my behaviour was quite hacky, so instead I added these commits to allow redefining a task in local.sh. I believe that can be useful for others as well.

The default behaviour without any customization of local.sh should remain unchanged.

Kind regards,
Ernest